### PR TITLE
Implement priority zone controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the MyPlaceIQ Home Assistant integration will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.3.0] - 2026-05-24
+### Added
+- Added control of Priorty zones, and moved sensors to be Binary sensors.
+
+## [1.2.0] - 2026-05-09
+### Added
+- Changed step size of temperature from 1.0 to 0.5.
+
 ## [1.1.0] - 2025-10-17
 ### Added
 - Ensure that climate entities are updated at the same time as the base entities and follow the same polling interval that is defined when configuring the integration.

--- a/custom_components/myplaceiq/__init__.py
+++ b/custom_components/myplaceiq/__init__.py
@@ -15,6 +15,8 @@ from .myplaceiq import MyPlaceIQ
 
 logger = logging.getLogger(__name__)
 
+PLATFORMS = ["sensor", "binary_sensor", "button", "climate"]
+
 async def async_setup(hass: HomeAssistant, config: dict) -> bool: # pylint: disable=unused-argument
     """Set up the MyPlaceIQ integration."""
     hass.data.setdefault(DOMAIN, {})
@@ -49,7 +51,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "myplaceiq": myplaceiq
         }
 
-        await hass.config_entries.async_forward_entry_setups(entry, ["sensor", "button", "climate"])
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
         entry.async_on_unload(entry.add_update_listener(async_reload_entry))
         logger.debug("Added update listener for entry: %s", entry.entry_id)
         return True
@@ -65,8 +67,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             logger.warning("Config entry %s not found in hass.data", entry.entry_id)
             return True
 
-        unload_ok = await hass.config_entries.async_unload_platforms(
-            entry, ["sensor", "button", "climate"])
+        unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
         if unload_ok:
             hass.data[DOMAIN].pop(entry.entry_id, None)
             logger.debug("Successfully unloaded entry: %s", entry.entry_id)

--- a/custom_components/myplaceiq/binary_sensor.py
+++ b/custom_components/myplaceiq/binary_sensor.py
@@ -1,0 +1,216 @@
+import json
+import logging
+import time
+from homeassistant.components.binary_sensor import BinarySensorEntity, BinarySensorDeviceClass
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from .const import DOMAIN
+
+logger = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up MyPlaceIQ binary sensor entities from a config entry."""
+    logger.debug("Setting up binary sensor entities for MyPlaceIQ")
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+    data = coordinator.data
+
+    if not isinstance(data, dict) or not data or "body" not in data:
+        logger.error("Invalid or missing coordinator data: %s", data)
+        return
+
+    try:
+        body = json.loads(data["body"])
+    except (json.JSONDecodeError, TypeError) as err:
+        logger.error("Failed to parse coordinator data body: %s", err)
+        return
+
+    aircons = body.get("aircons", {})
+    zones = body.get("zones", {})
+
+    entities = []
+
+    # Aircon on/off state
+    for aircon_id, aircon_data in aircons.items():
+        entities.append(
+            MyPlaceIQAirconStateBinarySensor(
+                coordinator=coordinator,
+                config_entry=config_entry,
+                aircon_id=aircon_id,
+                aircon_data=aircon_data,
+            )
+        )
+
+    # Per-zone: on/off state and priority state
+    for aircon_id, aircon_data in aircons.items():
+        for zone_id in aircon_data.get("zoneOrder", []):
+            zone_data = zones.get(zone_id)
+            if not zone_data or not zone_data.get("isVisible", False):
+                continue
+
+            entities.append(
+                MyPlaceIQZoneStateBinarySensor(
+                    coordinator=coordinator,
+                    config_entry=config_entry,
+                    zone_id=zone_id,
+                    zone_data=zone_data,
+                    aircon_id=aircon_id,
+                )
+            )
+
+            if zone_data.get("isPriorityZoneAllowed", False):
+                entities.append(
+                    MyPlaceIQZonePriorityBinarySensor(
+                        coordinator=coordinator,
+                        config_entry=config_entry,
+                        zone_id=zone_id,
+                        zone_data=zone_data,
+                        aircon_id=aircon_id,
+                    )
+                )
+
+    if entities:
+        async_add_entities(entities)
+        logger.debug("Added %d binary sensor entities", len(entities))
+    else:
+        logger.warning("No binary sensor entities created; check data structure")
+
+
+class MyPlaceIQAirconStateBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Binary sensor for MyPlaceIQ AC system on/off state."""
+
+    # pylint: disable=too-many-instance-attributes
+
+    def __init__(self, coordinator, config_entry, aircon_id, aircon_data):
+        super().__init__(coordinator)
+        self._aircon_id = aircon_id
+        self._config_entry = config_entry
+        self._name = aircon_data.get("name", "Aircon")
+        self._last_known_is_on = None
+        self._attr_unique_id = f"{config_entry.entry_id}_aircon_{aircon_id}_state"
+        self._attr_name = "HVAC State"
+        self._attr_device_class = BinarySensorDeviceClass.POWER
+        self._attr_icon = "mdi:power"
+
+    @property
+    def is_on(self):
+        """Return True when the AC is on."""
+        data = self.coordinator.data
+        if not isinstance(data, dict) or not data or "body" not in data:
+            return False
+        try:
+            body = json.loads(data["body"])
+            aircon = body.get("aircons", {}).get(self._aircon_id, {})
+            is_on = aircon.get("isOn",
+                self._last_known_is_on if self._last_known_is_on is not None else False)
+            if is_on:
+                self._last_known_is_on = is_on
+            logger.debug("Aircon %s state updated at %s: %s",
+                         self._attr_unique_id, time.strftime("%H:%M:%S"), is_on)
+            return bool(is_on)
+        except (json.JSONDecodeError, TypeError) as err:
+            logger.error("Failed to parse aircon state for %s: %s", self._attr_unique_id, err)
+            return False
+
+    @property
+    def device_info(self):
+        """Return device information."""
+        return {
+            "identifiers": {(DOMAIN, f"{self._config_entry.entry_id}_aircon_{self._aircon_id}")},
+            "name": f"Aircon {self._name}",
+            "manufacturer": "MyPlaceIQ",
+            "model": "Aircon",
+        }
+
+
+class MyPlaceIQZoneStateBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Binary sensor for MyPlaceIQ zone on/off state."""
+
+    # pylint: disable=too-many-instance-attributes
+
+    def __init__(self, coordinator, config_entry, zone_id, zone_data, aircon_id):
+        # pylint: disable=too-many-arguments, too-many-positional-arguments
+        super().__init__(coordinator)
+        self._zone_id = zone_id
+        self._aircon_id = aircon_id
+        self._config_entry = config_entry
+        self._name = zone_data.get("name", "Zone")
+        self._attr_unique_id = f"{config_entry.entry_id}_zone_{zone_id}_state"
+        self._attr_name = f"{self._name}_state".replace(" ", "_").lower()
+        self._attr_device_class = BinarySensorDeviceClass.POWER
+        self._attr_icon = "mdi:toggle-switch"
+
+    @property
+    def is_on(self):
+        """Return True when the zone is on."""
+        data = self.coordinator.data
+        if not isinstance(data, dict) or not data or "body" not in data:
+            return False
+        try:
+            body = json.loads(data["body"])
+            zone = body.get("zones", {}).get(self._zone_id, {})
+            is_on = zone.get("isOn", False)
+            logger.debug("Zone %s state updated at %s: %s",
+                         self._attr_unique_id, time.strftime("%H:%M:%S"), is_on)
+            return bool(is_on)
+        except (json.JSONDecodeError, TypeError) as err:
+            logger.error("Failed to parse zone state for %s: %s", self._attr_unique_id, err)
+            return False
+
+    @property
+    def device_info(self):
+        """Return device information."""
+        return {
+            "identifiers": {(DOMAIN, f"{self._config_entry.entry_id}_zone_{self._zone_id}")},
+            "name": f"Zone {self._name}",
+            "manufacturer": "MyPlaceIQ",
+            "model": "Zone",
+            "via_device": (DOMAIN, f"{self._config_entry.entry_id}_aircon_{self._aircon_id}"),
+        }
+
+
+class MyPlaceIQZonePriorityBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Binary sensor indicating whether a zone currently has priority enabled."""
+
+    # pylint: disable=too-many-instance-attributes
+
+    def __init__(self, coordinator, config_entry, zone_id, zone_data, aircon_id):
+        # pylint: disable=too-many-arguments, too-many-positional-arguments
+        super().__init__(coordinator)
+        self._zone_id = zone_id
+        self._aircon_id = aircon_id
+        self._config_entry = config_entry
+        self._name = zone_data.get("name", "Zone")
+        self._attr_unique_id = f"{config_entry.entry_id}_zone_{zone_id}_priority"
+        self._attr_name = f"{self._name}_priority".replace(" ", "_").lower()
+
+    @property
+    def is_on(self):
+        """Return True when this zone has priority enabled."""
+        data = self.coordinator.data
+        if not isinstance(data, dict) or not data or "body" not in data:
+            return False
+        try:
+            body = json.loads(data["body"])
+            zone = body.get("zones", {}).get(self._zone_id, {})
+            is_priority = zone.get("isPriorityZone", False)
+            logger.debug("Zone %s priority is_on: %s", self._zone_id, is_priority)
+            return bool(is_priority)
+        except (json.JSONDecodeError, TypeError) as err:
+            logger.error("Failed to parse priority state for zone %s: %s", self._zone_id, err)
+            return False
+
+    @property
+    def icon(self):
+        """Return a filled star when priority is active, outlined when not."""
+        return "mdi:star" if self.is_on else "mdi:star-outline"
+
+    @property
+    def device_info(self):
+        """Return device information — attach to the zone device."""
+        return {
+            "identifiers": {(DOMAIN, f"{self._config_entry.entry_id}_zone_{self._zone_id}")},
+            "name": f"Zone {self._name}",
+            "manufacturer": "MyPlaceIQ",
+            "model": "Zone",
+            "via_device": (DOMAIN, f"{self._config_entry.entry_id}_aircon_{self._aircon_id}"),
+        }

--- a/custom_components/myplaceiq/button.py
+++ b/custom_components/myplaceiq/button.py
@@ -92,13 +92,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             )
         ])
 
-    # Zone Buttons
+    # Zone Buttons (Toggle and Priority)
     for aircon_id, aircon_data in aircons.items():
         for zone_id in aircon_data.get("zoneOrder", []):
             zone_data = zones.get(zone_id)
-            if (zone_data and
-                zone_data.get("isVisible", False) and
-                zone_data.get("isClickable", False)):
+            if not zone_data or not zone_data.get("isVisible", False):
+                continue
+
+            # Toggle button (only for clickable zones)
+            if zone_data.get("isClickable", False):
                 entities.append(
                     MyPlaceIQButton(
                         coordinator=coordinator,
@@ -108,6 +110,23 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         entity_data=zone_data,
                         action="toggle",
                         command_type="SetZoneOpenClose",
+                        command_params=None,
+                        is_zone=True,
+                        aircon_id=aircon_id
+                    )
+                )
+
+            # Priority toggle button (for any zone where priority is allowed)
+            if zone_data.get("isPriorityZoneAllowed", False):
+                entities.append(
+                    MyPlaceIQButton(
+                        coordinator=coordinator,
+                        config_entry=config_entry,
+                        myplaceiq=myplaceiq,
+                        entity_id=zone_id,
+                        entity_data=zone_data,
+                        action="toggle_priority",
+                        command_type="SetPriorityZone",
                         command_params=None,
                         is_zone=True,
                         aircon_id=aircon_id
@@ -139,11 +158,17 @@ class MyPlaceIQButton(ButtonEntity):
         self._name = entity_data.get("name", f"{'Zone' if is_zone else 'Aircon'}")
         self._attr_unique_id = f"{config_entry.entry_id}_{'zone' if is_zone else 'aircon'}_{entity_id}_{action}" # pylint: disable=line-too-long
         self._attr_name = f"{self._name}_{action}".replace(" ", "_").lower()
-        self._attr_icon = (
-            "mdi:toggle-switch" if is_zone or action == "toggle" else
-            "mdi:thermostat"
-        )
+        self._attr_icon = self._resolve_icon(action, is_zone)
         self._attr_entity_category = EntityCategory.CONFIG
+
+    @staticmethod
+    def _resolve_icon(action, is_zone):
+        """Return an appropriate icon for the button action."""
+        if action == "toggle_priority":
+            return "mdi:star-circle"
+        if is_zone or action == "toggle":
+            return "mdi:toggle-switch"
+        return "mdi:thermostat"
 
     def _perform_optimistic_update(self, body, attribute, new_value):
         """Perform an optimistic update to coordinator.data and refresh the appropriate sensor."""
@@ -166,6 +191,20 @@ class MyPlaceIQButton(ButtonEntity):
             logger.warning(
                 "Could not perform optimistic update for %s %s %s: not found in data",
                     entity_type[:-1], self._entity_id, attribute)
+
+    def _perform_priority_optimistic_update(self, body, new_priority_state):
+        """Optimistically toggle isPriorityZone for this zone only."""
+        zones = body.get("zones", {})
+        zone = zones.get(self._entity_id, {})
+        zone["isPriorityZone"] = new_priority_state
+        zone["isPriorityZoneActive"] = new_priority_state
+        zones[self._entity_id] = zone
+        body["zones"] = zones
+        self.coordinator.data = {"body": json.dumps(body)}
+        logger.debug(
+            "Optimistically set isPriorityZone=%s for zone %s on aircon %s",
+            new_priority_state, self._entity_id, self._aircon_id
+        )
 
     async def async_press(self):
         """Handle button press for AC or zone commands."""
@@ -190,10 +229,10 @@ class MyPlaceIQButton(ButtonEntity):
                         }
                     ]
                 }
-                # Perform optimistic update
                 self._perform_optimistic_update(body, "isOn", new_state)
                 logger.debug("Sent toggle command for aircon %s to isOn=%s",
                             self._entity_id, new_state)
+
             elif self._command_type == "SetZoneOpenClose" and self._action == "toggle":
                 # Zone toggle: dynamically determine isOpen
                 zone = body.get("zones", {}).get(self._entity_id, {})
@@ -208,10 +247,28 @@ class MyPlaceIQButton(ButtonEntity):
                         }
                     ]
                 }
-                # Perform optimistic update
                 self._perform_optimistic_update(body, "isOn", new_state)
                 logger.debug("Sent toggle command for zone %s to isOpen=%s",
                             self._entity_id, new_state)
+
+            elif self._command_type == "SetPriorityZone" and self._action == "toggle_priority":
+                # Priority toggle: read current isPriorityZone and flip it
+                zone = body.get("zones", {}).get(self._entity_id, {})
+                current_priority = zone.get("isPriorityZone", False)
+                new_priority = not current_priority
+                command = {
+                    "commands": [
+                        {
+                            "__type": self._command_type,
+                            "zoneId": self._entity_id,
+                            "priorityEnabled": new_priority
+                        }
+                    ]
+                }
+                self._perform_priority_optimistic_update(body, new_priority)
+                logger.debug("Sent SetPriorityZone command for zone %s to priorityEnabled=%s",
+                            self._entity_id, new_priority)
+
             else:
                 # Mode commands: use predefined command_params
                 command = {
@@ -223,7 +280,6 @@ class MyPlaceIQButton(ButtonEntity):
                         }
                     ]
                 }
-                # Optimistic update for mode changes
                 if self._command_type == "SetAirconMode":
                     self._perform_optimistic_update(body, "mode", self._command_params["mode"])
                 logger.debug("Sent %s command for aircon %s: %s",

--- a/custom_components/myplaceiq/climate.py
+++ b/custom_components/myplaceiq/climate.py
@@ -2,7 +2,9 @@ import json
 import logging
 import time
 import asyncio
-from homeassistant.components.climate import ClimateEntity, ClimateEntityFeature, HVACMode
+from homeassistant.components.climate import (
+    ClimateEntity, ClimateEntityFeature, HVACMode, PRESET_NONE
+)
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
@@ -10,6 +12,9 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 
 logger = logging.getLogger(__name__)
+
+PRESET_PRIORITY = "priority"
+PRESET_NORMAL = PRESET_NONE
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
     """Set up MyPlaceIQ climate entities from a config entry."""
@@ -69,7 +74,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
 class MyPlaceIQClimate(CoordinatorEntity, ClimateEntity):
     # pylint: disable=too-many-instance-attributes
-    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_min_temp = 16
     _attr_max_temp = 30
@@ -102,7 +106,15 @@ class MyPlaceIQClimate(CoordinatorEntity, ClimateEntity):
             [HVACMode.AUTO, HVACMode.OFF] if is_zone else
             [HVACMode.HEAT, HVACMode.COOL, HVACMode.DRY, HVACMode.FAN_ONLY, HVACMode.OFF]
         )
-        self._last_known_is_on = None  # Cache last known isOn state
+        if is_zone and entity_data.get("isPriorityZoneAllowed", False):
+            self._attr_supported_features = (
+                ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
+            )
+            self._attr_preset_modes = [PRESET_PRIORITY, PRESET_NORMAL]
+        else:
+            self._attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+            self._attr_preset_modes = None
+        self._last_known_is_on = None
 
     def _handle_coordinator_update(self):
         """Handle updated data from the coordinator."""
@@ -207,6 +219,26 @@ class MyPlaceIQClimate(CoordinatorEntity, ClimateEntity):
             logger.error("Failed to parse HVAC mode for %s: %s", self._attr_unique_id, err)
             return HVACMode.OFF
 
+    @property
+    def preset_mode(self):
+        """Return the current preset mode for zone entities."""
+        if not self._is_zone or self._attr_preset_modes is None:
+            return None
+        data = self.coordinator.data
+        if not isinstance(data, dict) or not data or "body" not in data:
+            return PRESET_NORMAL
+        try:
+            body = json.loads(data["body"])
+            zone = body.get("zones", {}).get(self._entity_id, {})
+            is_priority = zone.get("isPriorityZone", False)
+            preset = PRESET_PRIORITY if is_priority else PRESET_NORMAL
+            logger.debug("Zone %s preset_mode: %s (isPriorityZone=%s)",
+                         self._attr_unique_id, preset, is_priority)
+            return preset
+        except (json.JSONDecodeError, TypeError) as err:
+            logger.error("Failed to parse preset mode for %s: %s", self._attr_unique_id, err)
+            return PRESET_NORMAL
+
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
         temperature = kwargs.get("temperature")
@@ -249,7 +281,7 @@ class MyPlaceIQClimate(CoordinatorEntity, ClimateEntity):
         self.async_write_ha_state()
 
         await self._myplaceiq.send_command(command)
-        await asyncio.sleep(2)  # Delay refresh to show optimistic state
+        await asyncio.sleep(2)
         await self.coordinator.async_request_refresh()
 
     async def async_set_hvac_mode(self, hvac_mode):
@@ -324,5 +356,39 @@ class MyPlaceIQClimate(CoordinatorEntity, ClimateEntity):
         self.async_write_ha_state()
 
         await self._myplaceiq.send_command(command)
-        await asyncio.sleep(2)  # Delay refresh to show optimistic state
+        await asyncio.sleep(2)
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_preset_mode(self, preset_mode):
+        """Set priority preset mode for zone entities."""
+        if not self._is_zone or self._attr_preset_modes is None:
+            logger.warning("Preset mode not supported for %s", self._attr_unique_id)
+            return
+
+        data = self.coordinator.data
+        if not isinstance(data, dict) or not data or "body" not in data:
+            return
+        body = json.loads(data["body"])
+
+        new_priority = preset_mode == PRESET_PRIORITY
+        command = {
+            "commands": [{
+                "__type": "SetPriorityZone",
+                "zoneId": self._entity_id,
+                "priorityEnabled": new_priority
+            }]
+        }
+
+        # Optimistic update
+        zone = body.get("zones", {}).get(self._entity_id, {})
+        zone["isPriorityZone"] = new_priority
+        zone["isPriorityZoneActive"] = new_priority
+        body["zones"][self._entity_id] = zone
+        self.coordinator.data["body"] = json.dumps(body)
+        logger.debug("Optimistic update for %s: set preset_mode to %s (isPriorityZone=%s)",
+                     self._attr_name, preset_mode, new_priority)
+        self.async_write_ha_state()
+
+        await self._myplaceiq.send_command(command)
+        await asyncio.sleep(2)
         await self.coordinator.async_request_refresh()

--- a/custom_components/myplaceiq/climate.py
+++ b/custom_components/myplaceiq/climate.py
@@ -13,7 +13,7 @@ from .const import DOMAIN
 
 logger = logging.getLogger(__name__)
 
-PRESET_PRIORITY = "priority"
+PRESET_PRIORITY = "Priority"
 PRESET_NORMAL = PRESET_NONE
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):

--- a/custom_components/myplaceiq/manifest.json
+++ b/custom_components/myplaceiq/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/anwickes/myplaceiq/issues",
   "requirements": ["aiohttp>=3.8.1"],
-  "version": "1.1.0"
+  "version": "1.3.0"
 }

--- a/custom_components/myplaceiq/sensor.py
+++ b/custom_components/myplaceiq/sensor.py
@@ -29,7 +29,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     entities = []
 
-    # AC System Sensors (Mode and State)
+    # AC System Sensors (Mode, State, and Priority Zone)
     for aircon_id, aircon_data in aircons.items():
         entities.extend([
             MyPlaceIQAirconSensor(
@@ -38,12 +38,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 aircon_id,
                 aircon_data
             ),
-            MyPlaceIQAirconStateSensor(
+            MyPlaceIQPriorityZoneSensor(
                 coordinator,
                 config_entry,
                 aircon_id,
-                aircon_data
-            )
+                aircon_data,
+                zones
+            ),
         ])
 
     # Zone Sensors (Temperature and State)
@@ -53,13 +54,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             if zone_data and zone_data.get("isVisible", False):
                 entities.extend([
                     MyPlaceIQZoneSensor(
-                        coordinator,
-                        config_entry,
-                        zone_id,
-                        zone_data,
-                        aircon_id
-                    ),
-                    MyPlaceIQZoneStateSensor(
                         coordinator,
                         config_entry,
                         zone_id,
@@ -152,54 +146,84 @@ class MyPlaceIQAirconSensor(CoordinatorEntity, SensorEntity):
             "model": "Aircon",
         }
 
-class MyPlaceIQAirconStateSensor(CoordinatorEntity, SensorEntity):
+class MyPlaceIQPriorityZoneSensor(CoordinatorEntity, SensorEntity):
     # pylint: disable=too-many-instance-attributes
-    """Sensor for MyPlaceIQ AC system on/off state."""
+    """Sensor reporting how many priority zones are currently active for an aircon system.
 
-    def __init__(self, coordinator, config_entry, aircon_id, aircon_data):
+    State: integer count of active priority zones (0 = none active).
+    Attributes: per-zone name -> bool map, so automations can inspect individual zones.
+    """
+
+    def __init__(self, coordinator, config_entry, aircon_id, aircon_data, zones):
+        # pylint: disable=too-many-arguments, too-many-positional-arguments
         super().__init__(coordinator)
         self._aircon_id = aircon_id
         self._config_entry = config_entry
         self._name = aircon_data.get("name", "Aircon")
-        self._attr_unique_id = f"{config_entry.entry_id}_aircon_{aircon_id}_state"
-        self._attr_name = f"{self._name}_state".replace(" ", "_").lower()
-        self._attr_icon = "mdi:power"
-        self._attr_device_class = SensorDeviceClass.POWER
+        self._attr_unique_id = f"{config_entry.entry_id}_aircon_{aircon_id}_priority_zone"
+        self._attr_name = "Priority Zones"
+        self._attr_icon = "mdi:star-circle"
+        self._attr_device_class = None
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._last_known_is_on = None
+
+    def _get_priority_zone_map(self, body):
+        """Return {zone_name: isPriorityZoneActive} for all priority-type zones."""
+        zones = body.get("zones", {})
+        return {
+            zone_data.get("name", zone_id): zone_data.get("isPriorityZone", False)
+            for zone_id, zone_data in zones.items()
+            if zone_data.get("zoneType") == "priority" or zone_data.get("isPriorityZoneAllowed", False)
+        }
 
     @property
     def state(self):
-        """Return the on/off state of the AC."""
+        """Return the count of currently active priority zones."""
         data = self.coordinator.data
         if not isinstance(data, dict) or not data or "body" not in data:
-            logger.debug("No valid coordinator data for aircon state %s", self._attr_unique_id)
+            logger.debug("No valid coordinator data for priority zone sensor %s",
+                         self._attr_unique_id)
             return None
         try:
             body = json.loads(data["body"])
-            aircon = body.get("aircons", {}).get(self._aircon_id, {})
-            is_on = aircon.get("isOn",
-                self._last_known_is_on if self._last_known_is_on is not None else False)
-            if is_on:
-                self._last_known_is_on = is_on
-            state = "on" if is_on else "off"
-            logger.debug("Aircon %s state updated at %s: %s (isOn=%s)",
-                         self._attr_unique_id, time.strftime("%H:%M:%S"), state, is_on)
-            return state
+            priority_map = self._get_priority_zone_map(body)
+            active_count = sum(1 for active in priority_map.values() if active)
+            logger.debug("Priority zone count for aircon %s: %d / %d",
+                         self._aircon_id, active_count, len(priority_map))
+            return active_count
         except (json.JSONDecodeError, TypeError) as err:
-            logger.error("Failed to parse coordinator data for aircon state %s: %s",
-                self._attr_unique_id, err)
+            logger.error("Failed to parse priority zone data for aircon %s: %s",
+                         self._aircon_id, err)
             return None
 
     @property
+    def extra_state_attributes(self):
+        """Return per-zone priority state and the names of all active priority zones."""
+        data = self.coordinator.data
+        if not isinstance(data, dict) or not data or "body" not in data:
+            return {}
+        try:
+            body = json.loads(data["body"])
+            priority_map = self._get_priority_zone_map(body)
+            active_zones = [name for name, active in priority_map.items() if active]
+            return {
+                "priority_zones": priority_map,        # {zone_name: bool} — all priority zones
+                "active_priority_zones": active_zones,  # [zone_name, ...] — only active ones
+            }
+        except (json.JSONDecodeError, TypeError) as err:
+            logger.error("Failed to parse priority zone attributes for aircon %s: %s",
+                         self._aircon_id, err)
+            return {}
+
+    @property
     def device_info(self):
-        """Return device information."""
+        """Return device information — attach to the parent aircon device."""
         return {
             "identifiers": {(DOMAIN, f"{self._config_entry.entry_id}_aircon_{self._aircon_id}")},
             "name": f"Aircon {self._name}",
             "manufacturer": "MyPlaceIQ",
             "model": "Aircon",
         }
+
 
 class MyPlaceIQZoneSensor(CoordinatorEntity, SensorEntity):
     # pylint: disable=too-many-instance-attributes
@@ -255,7 +279,9 @@ class MyPlaceIQZoneSensor(CoordinatorEntity, SensorEntity):
                 "target_temperature_heat": zone.get("targetTemperatureHeat"),
                 "target_temperature_cool": zone.get("targetTemperatureCool"),
                 "zone_type": zone.get("zoneType"),
-                "is_clickable": zone.get("isClickable", False)
+                "is_clickable": zone.get("isClickable", False),
+                "is_priority_zone": zone.get("isPriorityZone", False),
+                "is_priority_zone_active": zone.get("isPriorityZoneActive", False),
             }
             logger.debug("Zone %s attributes updated at %s: %s",
                          self._attr_unique_id, time.strftime("%H:%M:%S"), attributes)
@@ -276,51 +302,3 @@ class MyPlaceIQZoneSensor(CoordinatorEntity, SensorEntity):
             "via_device": (DOMAIN, f"{self._config_entry.entry_id}_aircon_{self._aircon_id}")
         }
 
-class MyPlaceIQZoneStateSensor(CoordinatorEntity, SensorEntity):
-    # pylint: disable=too-many-instance-attributes
-    """Sensor for MyPlaceIQ zone on/off state."""
-
-    def __init__(self, coordinator, config_entry, zone_id, zone_data, aircon_id):
-        # pylint: disable=too-many-arguments
-        # pylint: disable=too-many-positional-arguments
-        super().__init__(coordinator)
-        self._zone_id = zone_id
-        self._aircon_id = aircon_id
-        self._config_entry = config_entry
-        self._name = zone_data.get("name", "Zone")
-        self._attr_unique_id = f"{config_entry.entry_id}_zone_{zone_id}_state"
-        self._attr_name = f"{self._name}_state".replace(" ", "_").lower()
-        self._attr_icon = "mdi:toggle-switch"
-        self._attr_device_class = SensorDeviceClass.POWER
-        self._attr_state_class = SensorStateClass.MEASUREMENT
-
-    @property
-    def state(self):
-        """Return the on/off state of the zone."""
-        data = self.coordinator.data
-        if not isinstance(data, dict) or not data or "body" not in data:
-            logger.debug("No valid coordinator data for zone state %s", self._attr_unique_id)
-            return None
-        try:
-            body = json.loads(data["body"])
-            zone = body.get("zones", {}).get(self._zone_id, {})
-            state = "on" if zone.get("isOn", False) else "off"
-            logger.debug("Zone %s state updated at %s: %s (isOn=%s)",
-                         self._attr_unique_id, time.strftime("%H:%M:%S"),
-                            state, zone.get("isOn", "missing"))
-            return state
-        except (json.JSONDecodeError, TypeError) as err:
-            logger.error("Failed to parse coordinator data for zone state %s: %s",
-                self._attr_unique_id, err)
-            return None
-
-    @property
-    def device_info(self):
-        """Return device information."""
-        return {
-            "identifiers": {(DOMAIN, f"{self._config_entry.entry_id}_zone_{self._zone_id}")},
-            "name": f"Zone {self._name}",
-            "manufacturer": "MyPlaceIQ",
-            "model": "Zone",
-            "via_device": (DOMAIN, f"{self._config_entry.entry_id}_aircon_{self._aircon_id}")
-        }


### PR DESCRIPTION
Hey, first of all, thanks so much for the awesome integration. I use this literally every day. I hope you don't mind me contributing to it.

My HVAC system has "Priority zones" which are zones that get heating/cooling first. For me there must always be one set, which is a real pain if the room in use is cold, but the priorty zone is hogging all the heat.

With that in mind I inspected the json sent to/from my controller in Wireshark and made the following changes:
- Handing for priority zones, tracking active counts via a parent sensor while letting users toggle individual zone priority status via custom button handling and optimistic coordinator updates.
- Since i was creating a binary sensor anyway, I also refactored how existing on/off system statuses are exposed to Home Assistant by transitioning them to native binary_sensor components rather than string sensors. This does have the side-effect that the previous entities will show as unavailable in Home Assistant.

<img width="994" height="985" alt="image" src="https://github.com/user-attachments/assets/733d5837-e801-47f0-83ef-c1ac48ebeff1" />
